### PR TITLE
Potential fix for code scanning alert no. 4: Information exposure through an exception

### DIFF
--- a/api.py
+++ b/api.py
@@ -26,7 +26,8 @@ def set_category():
             "mappings": updated_mappings
         }), 200
     except Exception as e:
-        return jsonify({"error": str(e)}), 500
+        app.logger.error(f"Error in set_category: {e}")
+        return jsonify({"error": "An internal error has occurred."}), 500
 
 @app.route('/get_mappings', methods=['GET'])
 def get_mappings():
@@ -38,7 +39,8 @@ def get_mappings():
             "valid_categories": list(VALID_CATEGORIES)
         }), 200
     except Exception as e:
-        return jsonify({"error": str(e)}), 500
+        app.logger.error(f"Error in get_mappings: {e}")
+        return jsonify({"error": "An internal error has occurred."}), 500
 
 import os
 


### PR DESCRIPTION
Potential fix for [https://github.com/atoshv/GenAIEmailClassification/security/code-scanning/4](https://github.com/atoshv/GenAIEmailClassification/security/code-scanning/4)

To fix the problem, we need to ensure that detailed exception messages are not exposed to the end user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by modifying the exception handling in the `set_category` and `get_mappings` functions.

1. Import the `logging` module to log the detailed error messages.
2. Replace the return statements in the exception handling blocks to log the error and return a generic error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
